### PR TITLE
Pin astronauta-nvim to 2021-11-09 for Neovim <0.7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ You can also use it via [NUR][2] at `nur.repos.m15a.vimExtraPlugins`, see [the p
 | [terrortylor/nvim-comment](https://github.com/terrortylor/nvim-comment) | 2022-01-04 | `nvim-comment` |
 | [theniceboy/nvim-deus](https://github.com/theniceboy/nvim-deus) | 2021-08-26 | `nvim-deus` |
 | [titanzero/zephyrium](https://github.com/titanzero/zephyrium) | 2021-12-28 | `zephyrium` |
-| [tjdevries/astronauta.nvim](https://github.com/tjdevries/astronauta.nvim) | 2022-01-06 | `astronauta-nvim` |
+| [tjdevries/astronauta.nvim](https://github.com/tjdevries/astronauta.nvim) [branch: `edc19d30a3c51a8c3fc3f606008e5b4238821f1e`] | 2021-11-09 | `astronauta-nvim` |
 | [tjdevries/express_line.nvim](https://github.com/tjdevries/express_line.nvim) | 2021-12-01 | `express-line-nvim` |
 | [tjdevries/gruvbuddy.nvim](https://github.com/tjdevries/gruvbuddy.nvim) | 2021-04-15 | `gruvbuddy-nvim` |
 | [tjdevries/vlog.nvim](https://github.com/tjdevries/vlog.nvim) | 2020-08-04 | `vlog-nvim` |

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ You can also use it via [NUR][2] at `nur.repos.m15a.vimExtraPlugins`, see [the p
 | [RRethy/nvim-treesitter-textsubjects](https://github.com/RRethy/nvim-treesitter-textsubjects) | 2022-01-08 | `nvim-treesitter-textsubjects` |
 | [RishabhRD/gruvy](https://github.com/RishabhRD/gruvy) | 2022-01-09 | `gruvy` |
 | [RishabhRD/lspactions](https://github.com/RishabhRD/lspactions) | 2022-01-08 | `lspactions` |
+| [RishabhRD/lspactions](https://github.com/RishabhRD/lspactions) [branch: `nvim-0.6-compatible`] | 2022-01-08 | `lspactions-nvim06-compatible` |
 | [RishabhRD/nvim-rdark](https://github.com/RishabhRD/nvim-rdark) | 2020-12-25 | `nvim-rdark` |
 | [Th3Whit3Wolf/onebuddy](https://github.com/Th3Whit3Wolf/onebuddy) | 2021-04-01 | `onebuddy` |
 | [Th3Whit3Wolf/space-nvim](https://github.com/Th3Whit3Wolf/space-nvim) | 2021-07-08 | `space-nvim` |

--- a/manifest.txt
+++ b/manifest.txt
@@ -217,7 +217,7 @@ tanvirtin/vgit.nvim
 terrortylor/nvim-comment
 theniceboy/nvim-deus
 titanzero/zephyrium
-tjdevries/astronauta.nvim
+tjdevries/astronauta.nvim:edc19d30a3c51a8c3fc3f606008e5b4238821f1e
 tjdevries/express_line.nvim
 tjdevries/gruvbuddy.nvim
 tjdevries/vlog.nvim

--- a/manifest.txt
+++ b/manifest.txt
@@ -29,6 +29,7 @@ Pocco81/HighStr.nvim
 RRethy/nvim-treesitter-textsubjects
 RishabhRD/gruvy
 RishabhRD/lspactions
+RishabhRD/lspactions:nvim-0.6-compatible:lspactions-nvim06-compatible
 RishabhRD/nvim-rdark
 Th3Whit3Wolf/onebuddy
 Th3Whit3Wolf/space-nvim

--- a/overrides.nix
+++ b/overrides.nix
@@ -140,7 +140,7 @@ let
 
     jester = [ nvim-treesitter ];
 
-    lspactions = [ plenary-nvim popup-nvim self.astronauta-nvim ];
+    lspactions = [ plenary-nvim popup-nvim ];
 
     navigator-lua = [ nvim-lspconfig self.guihua-lua ];
 

--- a/overrides.nix
+++ b/overrides.nix
@@ -142,6 +142,8 @@ let
 
     lspactions = [ plenary-nvim popup-nvim ];
 
+    lspactions-nvim06-compatible = [ plenary-nvim popup-nvim self.astronauta-nvim ];
+
     navigator-lua = [ nvim-lspconfig self.guihua-lua ];
 
     neogen = [ nvim-treesitter ];

--- a/pkgs/vim-plugins.nix
+++ b/pkgs/vim-plugins.nix
@@ -2805,10 +2805,10 @@
   };
   astronauta-nvim = buildVimPluginFrom2Nix {
     pname = "astronauta-nvim";
-    version = "2022-01-06";
+    version = "2021-11-09";
     src = fetchurl {
-      url = "https://github.com/tjdevries/astronauta.nvim/archive/c8e33813c92ffcc9ba2edaf9124db1f3f17e3500.tar.gz";
-      sha256 = "0605hihdqwa2lksm89zk067kcqww373wl3l282kljjppgp6nsfdr";
+      url = "https://github.com/tjdevries/astronauta.nvim/archive/edc19d30a3c51a8c3fc3f606008e5b4238821f1e.tar.gz";
+      sha256 = "061lqiy6l5sbcgdipr2g6mxa4br703kp0q2pb78ldrf5kikbhif5";
     };
     meta = with lib; {
       description = "You now feel at home traveling to the moon";

--- a/pkgs/vim-plugins.nix
+++ b/pkgs/vim-plugins.nix
@@ -397,6 +397,18 @@
       homepage = "https://github.com/RishabhRD/lspactions";
     };
   };
+  lspactions-nvim06-compatible = buildVimPluginFrom2Nix {
+    pname = "lspactions-nvim06-compatible";
+    version = "2022-01-08";
+    src = fetchurl {
+      url = "https://github.com/RishabhRD/lspactions/archive/03953195a938b0a5d421d168461ff45e8e0874ed.tar.gz";
+      sha256 = "0jhpbjz353ybcxnq144059mfw6lvxgjf49rdj7158dq2vb88qbcw";
+    };
+    meta = with lib; {
+      description = "handlers for required lsp actions";
+      homepage = "https://github.com/RishabhRD/lspactions";
+    };
+  };
   nvim-rdark = buildVimPluginFrom2Nix {
     pname = "nvim-rdark";
     version = "2020-12-25";


### PR DESCRIPTION
[astronauta.nvim][1] has been deprecated for Neovim >=0.7.
Add `lspactions-nvim06-compatible` since [lspactions for Neovim <0.7][2] depends on previous revision of astronauta.

[1]: https://github.com/tjdevries/astronauta.nvim
[2]: https://github.com/RishabhRD/lspactions/tree/nvim-0.6-compatible