### PR TITLE
fix(mini-nvim): keep it for backward compatibility

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -225,6 +225,7 @@ let
     kanagawa-nvim
     litee-nvim
     lua-dev-nvim
+    mini-nvim
     nvim-ts-autotag
     # onedark-nvim is an alias to onedark-pro-nvim.
     # See https://github.com/NixOS/nixpkgs/pull/153045#discussion_r781641557


### PR DESCRIPTION
After care for #53.
Still not available in nixpkgs-unstable.