### PR TITLE
fix: path to nixpkgs vim plugins

### DIFF
--- a/bin/update-vim-plugins
+++ b/bin/update-vim-plugins
@@ -99,7 +99,7 @@
 (fn nixpkgs.get-vim-plugins-manifest [channel]
   "Fetch manifest of the official nixpkgs vim plugins."
   (let [channel (or channel "nixpkgs-unstable")
-        path (string.format "/NixOS/nixpkgs/%s/pkgs/misc/vim-plugins/vim-plugin-names" channel)
+        path (string.format "/NixOS/nixpkgs/%s/pkgs/applications/editors/vim/plugins/vim-plugin-names" channel)
         url (string.format "https://raw.githubusercontent.com%s" path)
         specs (: (http.get url) :split)]
     ;; Return it as a map from spec to bool for later convenience.


### PR DESCRIPTION
The path to vim plugins in nixpkgs has changed since https://github.com/NixOS/nixpkgs/commit/3f19fc37a3557d31b242b220b52c7a1358572f57.