### PR TITLE
fix: ignore plugins not hosted by github/gitlab

### DIFF
--- a/bin/update-vim-plugins
+++ b/bin/update-vim-plugins
@@ -260,7 +260,8 @@
           :github (if (full-name:match "feline%.nvim")
                       "feline-nvim/feline.nvim" ; hot fix due to organization change
                       full-name)
-          _ (error "undefined repo type"))))))
+          ;; Ignore plugins hosted by other than github/gitlab, e.g., sourcehut.
+          _ nil)))))
 
 ;;; ------------------------------------------------------------------------------------------------
 ;;; Manifest spec parser


### PR DESCRIPTION
Recent awesome-neovim list contains plugins hosted by other than github/gitlab like sourcehut.
Fix https://github.com/m15a/nixpkgs-vim-extra-plugins/actions/runs/2678916047.