### PR TITLE
feat: add sychen52/smart-term-esc.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ You can also use it via [NUR][2] at `nur.repos.m15a.vimExtraPlugins`, see [the p
 | [sunjon/Shade.nvim](https://github.com/sunjon/Shade.nvim) | 2022-02-01 | `Shade-nvim` |
 | [svermeulen/vim-yoink](https://github.com/svermeulen/vim-yoink) | 2021-09-15 | `vim-yoink` |
 | [svermeulen/vimpeccable](https://github.com/svermeulen/vimpeccable) | 2021-12-28 | `vimpeccable` |
+| [sychen52/smart-term-esc.nvim](https://github.com/sychen52/smart-term-esc.nvim) | 2021-09-27 | `smart-term-esc-nvim` |
 | [tamago324/lir.nvim](https://github.com/tamago324/lir.nvim) | 2022-05-17 | `lir-nvim` |
 | [tamago324/nlsp-settings.nvim](https://github.com/tamago324/nlsp-settings.nvim) | 2022-07-31 | `nlsp-settings-nvim` |
 | [tamton-aquib/staline.nvim](https://github.com/tamton-aquib/staline.nvim) | 2022-06-17 | `staline-nvim` |

--- a/manifest.txt
+++ b/manifest.txt
@@ -430,6 +430,7 @@ sudormrfbin/cheatsheet.nvim
 sunjon/Shade.nvim
 svermeulen/vim-yoink
 svermeulen/vimpeccable
+sychen52/smart-term-esc.nvim
 tamago324/lir.nvim
 tamago324/nlsp-settings.nvim
 tamton-aquib/staline.nvim

--- a/pkgs/vim-plugins.nix
+++ b/pkgs/vim-plugins.nix
@@ -5521,6 +5521,18 @@
       license = with licenses; [ mit ];
     };
   };
+  smart-term-esc-nvim = buildVimPluginFrom2Nix {
+    pname = "smart-term-esc-nvim";
+    version = "2021-09-27";
+    src = fetchurl {
+      url = "https://github.com/sychen52/smart-term-esc.nvim/archive/168cd1a9e4649038e356b293005e5714e6e9f190.tar.gz";
+      sha256 = "1lldf028a9a3a721avrwzai60msiaib30a18rsa98wa5fnvsi60j";
+    };
+    meta = with lib; {
+      description = "Escape terminal \"smartly\" with <Esc> in Neovim";
+      homepage = "https://github.com/sychen52/smart-term-esc.nvim";
+    };
+  };
   lir-nvim = buildVimPluginFrom2Nix {
     pname = "lir-nvim";
     version = "2022-05-17";


### PR DESCRIPTION
[sychen52/smart-term-esc.nvim](https://github.com/sychen52/smart-term-esc.nvim) is a nice plugin that enables escaping from insert mode by `<Esc>` key  in `:terminal` when it has no problem. See https://github.com/neovim/neovim/issues/7648 for more information.
