### PR TITLE
feat: add hkupty/iron.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ You can also use it via [NUR][2] at `nur.repos.m15a.vimExtraPlugins`, see [the p
 | [haringsrob/nvim_context_vt](https://github.com/haringsrob/nvim_context_vt) | 2022-04-19 | `nvim-context-vt` |
 | [henriquehbr/ataraxis.lua](https://github.com/henriquehbr/ataraxis.lua) | 2022-07-03 | `ataraxis-lua` |
 | [henriquehbr/nvim-startup.lua](https://github.com/henriquehbr/nvim-startup.lua) | 2022-07-03 | `nvim-startup-lua` |
+| [hkupty/iron.nvim](https://github.com/hkupty/iron.nvim) | 2022-07-11 | `iron-nvim` |
 | [hkupty/nvimux](https://github.com/hkupty/nvimux) | 2022-05-02 | `nvimux` |
 | [houtsnip/vim-emacscommandline](https://github.com/houtsnip/vim-emacscommandline) | 2017-11-24 | `vim-emacscommandline` |
 | [hrsh7th/cmp-buffer](https://github.com/hrsh7th/cmp-buffer) | 2022-06-15 | `cmp-buffer` |

--- a/manifest.txt
+++ b/manifest.txt
@@ -188,6 +188,7 @@ h-hg/fcitx.nvim
 haringsrob/nvim_context_vt
 henriquehbr/ataraxis.lua
 henriquehbr/nvim-startup.lua
+hkupty/iron.nvim
 hkupty/nvimux
 houtsnip/vim-emacscommandline
 hrsh7th/cmp-buffer

--- a/pkgs/vim-plugins.nix
+++ b/pkgs/vim-plugins.nix
@@ -2423,6 +2423,19 @@
       license = with licenses; [ mit ];
     };
   };
+  iron-nvim = buildVimPluginFrom2Nix {
+    pname = "iron-nvim";
+    version = "2022-07-11";
+    src = fetchurl {
+      url = "https://github.com/hkupty/iron.nvim/archive/8fe71532ff25020970b0d216c22525f92097d573.tar.gz";
+      sha256 = "0k6qyqd8x47nxq1j1jlp5drg6afghgvfsrjbs08glxgwnclil35n";
+    };
+    meta = with lib; {
+      description = "Interactive Repl Over Neovim";
+      homepage = "https://github.com/hkupty/iron.nvim";
+      license = with licenses; [ bsd3 ];
+    };
+  };
   nvimux = buildVimPluginFrom2Nix {
     pname = "nvimux";
     version = "2022-05-02";


### PR DESCRIPTION
Not sure why [hkupty/iron.nvim](https://github.com/hkupty/iron.nvim) is currently not available in this overlay. It should be.