### PR TITLE
fix(glow-nvim): allow markdown sub filetypes to be previewed

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -259,6 +259,16 @@ let
       ];
     });
 
+    glow-nvim = super.glow-nvim.overrideAttrs (old: {
+      patches = (old.patches or []) ++ [
+        # https://github.com/ellisonleao/glow.nvim/pull/80
+        (final.fetchpatch {
+          url = "https://github.com/ellisonleao/glow.nvim/pull/80/commits/16a348ffa8022945f735caf708c2bd601b08272c.patch";
+          sha256 = "sha256-fljlBTHcoPjnavF37yoIs3zrZ3+iOX6oQ0e20AKtNI8=";
+        })
+      ];
+    });
+
     guihua-lua = super.guihua-lua.overrideAttrs (old: {
       buildPhase = ''
         (


### PR DESCRIPTION
There are some vim plugins that provide markdown sub filetypes such as `markdown.pandoc` in [vim-pandoc/vim-pandoc-syntax](https://github.com/vim-pandoc/vim-pandoc-syntax). However, current [glow.nvim](https://github.com/ellisonleao/glow.nvim) previews markdown file only when its filetype is `markdown`. It would be better if the filetype check is more forgiving.

This is a temporal fix until https://github.com/ellisonleao/glow.nvim/pull/80 or the other patch that fixes this problem gets merged.