### PR TITLE
fix(github): check fails on PR from forked repo

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,8 +26,6 @@ jobs:
     name: Check builds in nixpkgs-unstable
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
       - uses: cachix/install-nix-action@v17
         with:
           extra_nix_config: |


### PR DESCRIPTION
https://github.com/m15a/nixpkgs-vim-extra-plugins/actions/runs/2853374006:

    Fetching the repository
      /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/add-vim-printer*:refs/remotes/origin/add-vim-printer* +refs/tags/add-vim-printer*:refs/tags/add-vim-printer*
      The process '/usr/bin/git' failed with exit code 1
      Waiting 20 seconds before trying again

See https://github.com/actions/checkout/issues/366.
Note that in actions/checkout, default `ref` is `github.ref`.