### PR TITLE
fix(SmoothCursor-nvim): mark as broken

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -11,6 +11,8 @@ let
     meta = old.meta // { inherit broken; };
   }))
   {
+    SmoothCursor-nvim = true;
+
     go-nvim = true;
 
     highlight-current-n-nvim = true;


### PR DESCRIPTION
https://github.com/m15a/nixpkgs-vim-extra-plugins/actions/runs/3092969213/jobs/5004819564

    > E154: Duplicate tag "smoothcursor-utils-smoothcursor_start" in file /nix/store/033dk3haq5gh6vcwwnr1j7nm68iww2pi-vimplugin-SmoothCursor-nvim-2022-09-20/./doc/smoothscroll.txt
    > E154: Duplicate tag "smoothcursor-utils-smoothcursor_start" in file /nix/store/033dk3haq5gh6vcwwnr1j7nm68iww2pi-vimplugin-SmoothCursor-nvim-2022-09-20/./doc/smoothscroll.txtFailed to build help tags!