### PR TITLE
fix(lspsaga-nvim): defined in the official nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,6 @@ You can also use it via [NUR][2] at `nur.repos.m15a.vimExtraPlugins`, see [the p
 | [kdheepak/monochrome.nvim](https://github.com/kdheepak/monochrome.nvim) | 2021-07-14 | `monochrome-nvim` |
 | [keaising/im-select.nvim](https://github.com/keaising/im-select.nvim) | 2022-07-31 | `im-select-nvim` |
 | [kevinhwang91/nvim-ufo](https://github.com/kevinhwang91/nvim-ufo) | 2022-10-03 | `nvim-ufo` |
-| [kkharji/lspsaga.nvim](https://github.com/kkharji/lspsaga.nvim) | 2022-08-20 | `lspsaga-nvim` |
 | [kkharji/sqlite.lua](https://github.com/kkharji/sqlite.lua) | 2022-10-01 | `sqlite-lua` |
 | [klen/nvim-test](https://github.com/klen/nvim-test) | 2022-06-05 | `nvim-test` |
 | [kmonad/kmonad-vim](https://github.com/kmonad/kmonad-vim) | 2022-03-20 | `kmonad-vim` |

--- a/blacklist.txt
+++ b/blacklist.txt
@@ -200,3 +200,4 @@ winston0410/range-highlight.nvim
 yamatsum/nvim-cursorline
 yamatsum/nvim-nonicons
 meain/vim-printer
+kkharji/lspsaga.nvim

--- a/manifest.txt
+++ b/manifest.txt
@@ -184,7 +184,6 @@ kazhala/close-buffers.nvim
 kdheepak/monochrome.nvim
 keaising/im-select.nvim
 kevinhwang91/nvim-ufo
-kkharji/lspsaga.nvim
 kkharji/sqlite.lua
 klen/nvim-test
 kmonad/kmonad-vim

--- a/overrides.nix
+++ b/overrides.nix
@@ -378,6 +378,7 @@ let
     nvim-cursorline
     nvim-nonicons
     vim-printer
+    lspsaga-nvim
     ;
   } // (with final.vimPlugins; {
     # FIXME: error: Alias TrueZen-nvim is still in vim-plugins

--- a/pkgs/vim-plugins.nix
+++ b/pkgs/vim-plugins.nix
@@ -2372,19 +2372,6 @@
       license = with licenses; [ bsd3 ];
     };
   };
-  lspsaga-nvim = buildVimPluginFrom2Nix {
-    pname = "lspsaga-nvim";
-    version = "2022-08-20";
-    src = fetchurl {
-      url = "https://github.com/kkharji/lspsaga.nvim/archive/9ec569a49aa7ff265764081acff9e5da839c13fe.tar.gz";
-      sha256 = "0206igfxs1imgj8dalvi5mhi49q5qj4hrm2y21x0w1wv9f07g2n1";
-    };
-    meta = with lib; {
-      description = "The neovim language-server-client UI";
-      homepage = "https://github.com/kkharji/lspsaga.nvim";
-      license = with licenses; [ mit ];
-    };
-  };
   sqlite-lua = buildVimPluginFrom2Nix {
     pname = "sqlite-lua";
     version = "2022-10-01";


### PR DESCRIPTION
    error: attribute 'lspsaga-nvim' already defined at /nix/store/ysxvvf4m61mc4hqfjbl37nhjzj0bffx2-source/pkgs/vim-plugins.nix:1861:3

       at /nix/store/ysxvvf4m61mc4hqfjbl37nhjzj0bffx2-source/pkgs/vim-plugins.nix:2375:3:

         2374|   };
         2375|   lspsaga-nvim = buildVimPluginFrom2Nix {
             |   ^
         2376|     pname = "lspsaga-nvim";